### PR TITLE
Support nested string-based directory retrieval

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
@@ -188,6 +188,32 @@ class vfsStreamDirectory extends vfsStreamAbstractContent implements vfsStreamCo
         return null;
     }
 
+	/**
+	 * @param string $path
+	 * @return \org\bovigo\vfs\vfsStreamContent|\org\bovigo\vfs\vfsStreamDirectory
+	 * @throws vfsStreamException
+	 */
+	public function getChildByPath($path)
+	{
+		$aPath = explode('/', $path);
+		$child = $this->getChild($aPath[0]);
+		array_shift($aPath);
+
+		if($aPath){
+			foreach($aPath as $childName){
+				$tmp = $child->getChild($childName);
+				if($tmp){
+					$child = $tmp;
+				}
+				else{
+					throw new vfsStreamException("Cannot find child `$childName` while searching for `$path` ");
+				}
+			}
+		}
+
+		return $child;
+	}
+
     /**
      * helper method to detect the real child name
      *


### PR DESCRIPTION
I think there should be a shorter syntax for getting child from deep level, so that its possible to navigate not with..
```
$rootDir = vfsStreamWrapper::getRoot();
$rootDir->getChild('library')->getChild('1')->getChild('1')->getChild('1')->getChild('bb2075d7d7023ebd5929f6a3f4c4d499')
```
But more naturally, like this..
```
$rootDir->getChildByPath('library/1/1/1/bb2075d7d7023ebd5929f6a3f4c4d499')
```